### PR TITLE
Specify using "-ansi" option during compiling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX=$(HOME)
 CC=g++
 AR=ar
-CFLAGS= -Wall -O3
+CFLAGS= -ansi -Wall -O3
 LDFLAGS= -L. -lfhew -lfftw3 
 INCLUDE=distrib.h LWE.h FHEW.h FFT.h params.h
 


### PR DESCRIPTION
I meet similar issues like #5 and #6 when using `gcc 6.2.1` to compile code. The solution is just specifying "`-ansi`" option. Some compilers don't use "`-ansi`" as default `C++` compile option, and this may lead errors.