### PR TITLE
Simplified accumulator

### DIFF
--- a/FHEW.cpp
+++ b/FHEW.cpp
@@ -8,8 +8,11 @@ using namespace std;
 namespace FHEW {
 
   typedef Ring_ModQ ct_ModQ[K2][2];   // Ciphertext in coefficient form
+  typedef Ring_ModQ ct_ModQ1[2];   // Entry C[1] of ct_ModQ
   typedef Ring_ModQ dct_ModQ[K2][K2]; // Decomposed Ciphertext in coeff form
+  typedef Ring_ModQ dct_ModQ1[K2]; // Entry C[1] of dct_ModQ
   typedef Ring_FFT  dct_FFT[K2][K2];  // Decomposed Ciphertext in FFT form
+  typedef Ring_FFT  dct_FFT1[K2];  // Entry C[1] of dct_FFT
   
   Ring_FFT t_TestMSB;
   
@@ -93,69 +96,62 @@ namespace FHEW {
     return EK;
   }
 
-  void AddToACC(ct_FFT ACC, ct_FFT C) {
-    ct_ModQ ct;
-    dct_ModQ dct;
-    dct_FFT dctFFT;
-    // Decompose_ct(dctFFT, ACC);
-    for (int i = 0; i < K2; ++i)
-      for (int j = 0; j < 2; ++j)
-	FFTbackward(ct[i][j], ACC[i][j]);
-    for (int i = 0; i < K2; ++i)
-      for (int j = 0; j < 2; ++j)
-	for (int k = 0; k < N; ++k) {
-	  ZmodQ t = ct[i][j][k] * v_inverse;
-	  for (int l = 0; l < K; ++l) {
-	    ZmodQ r = (t << g_bits_32[l]) >> g_bits_32[l];
-//      if ((l==2) && (k ==0 ))
-//       cout << r << ",";
-	    t = (t-r) >> g_bits[l];
-	    dct[i][j+2*l][k] = r;
-	  }
-	}
-    for (int i = 0; i < K2; ++i)
-      for (int j = 0; j < K2; ++j)
-	FFTforward(dctFFT[i][j], dct[i][j]);
-    // Mult_dct_ct(ACC, dct, C);
-    for (int i = 0; i < K2; ++i)     
-      for (int j = 0; j < 2; ++j)
-	for (int k = 0; k < N2; ++k) {
-	  ACC[i][j][k] = (double complex) 0.0;
-	  for (int l = 0; l < K2; ++l)
-	    ACC[i][j][k] += ((double complex) dctFFT[i][l][k]) * ((double complex) C[l][j][k]);
-	}
-  }
+  typedef Ring_FFT ct_FFT1[2]; // C[1] entry of ct_FFT ciphertext
   
-  void InitializeACC(ct_FFT ACC, int m) {	// Set a ciphertext to X^m * G (encryption of m without errors)
-    ct_ModQ res;
+  void AddToACC(ct_FFT1 ACC, ct_FFT C) {
+    ct_ModQ1 ct;
+    dct_ModQ1 dct;
+    dct_FFT1 dctFFT;
+    // Decompose_ct(dctFFT, ACC);
+    for (int j = 0; j < 2; ++j)
+      FFTbackward(ct[j], ACC[j]);
+    for (int j = 0; j < 2; ++j)
+      for (int k = 0; k < N; ++k) {
+	ZmodQ t = ct[j][k] * v_inverse;
+	for (int l = 0; l < K; ++l) {
+	  ZmodQ r = (t << g_bits_32[l]) >> g_bits_32[l];
+	  //      if ((l==2) && (k ==0 ))
+	  //       cout << r << ",";
+	  t = (t-r) >> g_bits[l];
+	  dct[j+2*l][k] = r;
+	}
+      }
+    for (int j = 0; j < K2; ++j)
+      FFTforward(dctFFT[j], dct[j]);
+    // Mult_dct_ct(ACC, dct, C);
+    for (int j = 0; j < 2; ++j)
+      for (int k = 0; k < N2; ++k) {
+	ACC[j][k] = (double complex) 0.0;
+	for (int l = 0; l < K2; ++l)
+	  ACC[j][k] += ((double complex) dctFFT[l][k]) * ((double complex) C[l][j][k]);
+      }
+      }
+  
+  void InitializeACC(ct_FFT1 ACC, int m) {	// Set a ciphertext to X^m * G (encryption of m without errors)
+    ct_ModQ1 res;
     int mm = (((m % q) + q) % q) * (2*N/q);             // Reduce mod q (dealing with negative number as well)
     int sign = 1;
     if (mm >= N) { mm -= N; sign = -1; }
     
-    for (int i = 0; i < K2; ++i)
-      for (int j = 0; j < 2; ++j)
-	for (int k = 0; k < N; ++k)
-	  res[i][j][k]=0;
-    for (int i = 0; i < K; ++i) {
-      res[2*i  ][0][mm] += sign*vgprime[i]; // Add G Multiple
-      res[2*i+1][1][mm] += sign*vgprime[i]; // [a,as+e] + X^m *G
-    }
-    for (int i = 0; i < K2; ++i)
-      for (int j = 0; j < 2; ++j)
-	FFTforward(ACC[i][j], res[i][j]);
+    for (int j = 0; j < 2; ++j)
+      for (int k = 0; k < N; ++k)
+	res[j][k]=0;
+    res[1][mm] += sign*vgprime[0]; // [a,as+e] + X^m *G
+    for (int j = 0; j < 2; ++j)
+      FFTforward(ACC[j], res[j]);
   }
   
-  LWE::CipherTextQN* MemberTest(Ring_FFT t, ct_FFT C) {
+  LWE::CipherTextQN* MemberTest(Ring_FFT t, ct_FFT1 C) {
     Ring_FFT temp;
     Ring_ModQ temp_ModQ;
     
     LWE::CipherTextQN* ct = new LWE::CipherTextQN;
     for (int i = 0; i < N2; ++i)
-      temp[i] = conj(((double complex) C[1][0][i]) * ((double complex)t[i]));  // Compute t*a
+      temp[i] = conj(((double complex) C[0][i]) * ((double complex)t[i]));  // Compute t*a
     FFTbackward(temp_ModQ, temp);
     for (int i = 0; i < N; ++i) ct->a[i] = temp_ModQ[i];
     for (int i = 0; i < N2; ++i)
-      temp[i] = ((double complex) C[1][1][i]) * ((double complex) t[i]);
+      temp[i] = ((double complex) C[1][i]) * ((double complex) t[i]);
     FFTbackward(temp_ModQ, temp);
     ct->b = v+temp_ModQ[0];	
     return ct;    
@@ -167,7 +163,7 @@ namespace FHEW {
       e12.a[i] = (2*q - (ct1.a[i] + ct2.a[i])) % q;
     e12.b  =  (13 * q / 8) - (ct1.b + ct2.b) % q;
 
-    ct_FFT ACC;
+    ct_FFT1 ACC;
     InitializeACC(ACC, (e12.b + q/4) % q);
     for (int i = 0; i < n; ++i) {
       int a = (q - e12.a[i] % q) % q;


### PR DESCRIPTION
All functions to initialize, modify or test accumulator only use entry ACC[1].
Removed unnecessary entries to simplify code and speed up execution.